### PR TITLE
Change Sniper Rifle's Ammo to SHELLS

### DIFF
--- a/scripts/ff_weapon_sniperrifle.txt
+++ b/scripts/ff_weapon_sniperrifle.txt
@@ -26,7 +26,7 @@ WeaponData
 	"clip2_size"	"-1"
 	"default_clip"	"60"
 	"default_clip2"	"-1"
-	"primary_ammo"	"AMMO_NAILS"
+	"primary_ammo"	"AMMO_SHELLS"
 	"secondary_ammo"	"None"
 
 	"ffencrypted"	"1" // required for the script to load


### PR DESCRIPTION
Merging ammo pools between the Sniper Rifle and Autorifle makes Sniper less campy and standardizes his ammo pools to those of TFC and QWTF (which also share shells between the two weapons). This would also improve the balance of FF as currently Sniper has 75 effective shots in the most powerful weapon in the game and it consumes one ammo at a time. Sniper was more balanced when he had to choose to sacrifice extra Sniper Rifle shots to use the Autorifle.