### PR TITLE
Make the Super Nailgun Fire 2 Nails per Shot (with clip of 100)

### DIFF
--- a/scripts/ff_weapon_supernailgun.txt
+++ b/scripts/ff_weapon_supernailgun.txt
@@ -2,7 +2,7 @@ WeaponData
 {
 	// Weapon characteristics:
 	"CycleTime"	"0.1"		// Rate of fire
-	"CycleDecrement"	"1"	// Number of bullets fired per cycle
+	"CycleDecrement"	"2"	// Number of bullets fired per cycle
 	"ReloadClip"	"1"	// Reload entire clip at once?
 
 	"Damage"	"12"		// Damage per burst
@@ -22,9 +22,9 @@ WeaponData
 
 	"SpinTime"	"-1"		// For AC
 
-	"clip_size"	"50"
+	"clip_size"	"100"
 	"clip2_size"	"-1"
-	"default_clip"	"60"
+	"default_clip"	"100"
 	"default_clip2"	"-1"
 	"primary_ammo"	"AMMO_NAILS"
 	"secondary_ammo"	"None"


### PR DESCRIPTION
Currently, the Super Nailgun has alot of extra ammo, even for the standards of Team Fortress. Considering Medic is the most powerful offensive class in the game, he should run through his nails a bit faster than he currently does (he currently has the ability to sit and spam the most amount of nails in the game with the highest projectile dps in the game). Also, the Super Nailgun consumed 2 nails at a time in TFC and QUAKE, and this would serve to make the Super Nailgun more standardized with the games it draws inspiration from while making the weapon feel more familiar to players of these games. Additionally, it adds mechanical depth to the game by making all "Super" weapons consume 2 ammo per shot, giving more gamefeel variety to the classes of FF.