### PR TITLE
Reduce Spy's Armor to 70

### DIFF
--- a/scripts/ff_playerclass_spy.txt
+++ b/scripts/ff_playerclass_spy.txt
@@ -15,7 +15,7 @@ PlayerClassData
 	"arm_model"			"models/player/arms/spy_arms.mdl"
 
 	// Health & Armour
-	"max_armour"		"100"
+	"max_armour"		"70"
 	"initial_armour"		"25"
 	"armour_type"		"6" // this means 0.6
 	"health"			"90"


### PR DESCRIPTION
Spy currently stands as a very powerful attacking class with more damage potential than Medic if he is played correctly. His playstyle encourages point-blank combat and it can be hard to deter spies who are playing like this because they have the same tankiness as a Medic. Spy should also have slightly less effective hp than Medic because of his ability to cloak and escape dangerous situations. This would create a more high-risk high-reward experience for the Spy. Additionally, Spy was also reduced to 70 armor in TF2003 (the current played fork of QWTF for Russians), and having tested the change myself I can say this feels like a satisfying amount of vitality for the Spy compared to Medic. This change would also further differentiate Spy and Medic.