### PR TITLE
Reduce IC Fire Rate to 0.8

### DIFF
--- a/scripts/ff_weapon_ic.txt
+++ b/scripts/ff_weapon_ic.txt
@@ -1,7 +1,7 @@
 WeaponData
 {
 	// Weapon characteristics:
-	"CycleTime"	"0.6"		// Rate of fire
+	"CycleTime"	"0.8"		// Rate of fire
 	"CycleDecrement"	"1"	// Number of bullets fired per cycle
 	"DeployDelay"	"0.2"		// Delay before you can shoot when you first pull the weapon out
 	


### PR DESCRIPTION
The current IC is very good at juggling enemies, doing 65 damage every time. If Pyro is going to be a combo class, he should work for proper combos instead of abusing mindless spam. Unsurprisingly, spam is annoying, and Pyro can use it to output lots of damage with no way to stop it due to knockback.