### PR TITLE
Halve the Damage, Double the Fire Rate (same dps with less ammo effic…

### DIFF
--- a/scripts/ff_weapon_flamethrower.txt
+++ b/scripts/ff_weapon_flamethrower.txt
@@ -1,11 +1,11 @@
 WeaponData
 {
 	// Weapon characteristics:
-	"CycleTime"	"0.2"		// Rate of fire
+	"CycleTime"	"0.1"		// Rate of fire (used to be 0.2)
 	"CycleDecrement"	"1"	// Number of bullets fired per cycle
 	"DeployDelay"	"0.2"		// Delay before you can shoot when you first pull the weapon out
 
-	"Damage"	"18"		// Damage per burst (used to be 9)
+	"Damage"	"9"		// Damage per burst (used to be 18)
 
 	"RecoilAmount"	"0"	// Amount of recoil
 


### PR DESCRIPTION
…iency)

In other TF games, the flamethrower consumes ammo much faster. This change will double the flamethrower's current ammo consumption while keeping its dps the same. This will improve Pyro's ammo economy by allowing less spam/mindless firing of the flamethrower.