### PR TITLE
Reduce Pyro's Reserve Rockets to 20

### DIFF
--- a/scripts/ff_playerclass_pyro.txt
+++ b/scripts/ff_playerclass_pyro.txt
@@ -58,7 +58,7 @@ PlayerClassData
 		"AMMO_SHELLS"		"40"
 		"AMMO_NAILS"		"50"
 		"AMMO_CELLS"		"200"
-		"AMMO_ROCKETS"		"25"
+		"AMMO_ROCKETS"		"20"
 		"AMMO_DETPACK"		"0"
 		"AMMO_MANCANNON"	"0"
 	}


### PR DESCRIPTION
Matching Pyro's reserve rockets to TFC and his effective amount of rockets in QWTF. This will also help reduce IC spam.