### PR TITLE
Reduce the Autorifle's Spread

### DIFF
--- a/scripts/ff_weapon_autorifle.txt
+++ b/scripts/ff_weapon_autorifle.txt
@@ -13,7 +13,7 @@ WeaponData
 	
 	// Hitscan weapons
 	"Bullets"	"1"		// Bullets to shoot
-	"BulletSpread"	"0.07"	// Spread of projectiles
+	"BulletSpread"	"0.02"	// Spread of projectiles (Used to be 0.07)
 
 	"PreReloadTime"	"-1"	// Time taken for the weapon to move to reload state
 	"ReloadTime"	"-1"		// Time taken to reload a shell/rocket/etc


### PR DESCRIPTION
In other TF games, the Autorifle is perfectly accurate. While I find that too powerful, I believe the Autorifle's spread could be tightened to reflect its more accurate nature in these other games. Also, the current Autorifle suffers at closer ranges sometimes because its spread can cause bullets to miss when in my opinion they should not.