### PR TITLE
Make the Tranq Gun Consume 5 Nails Per Shot

### DIFF
--- a/scripts/ff_weapon_tranq.txt
+++ b/scripts/ff_weapon_tranq.txt
@@ -2,7 +2,7 @@ WeaponData
 {
 	// Weapon characteristics:
 	"CycleTime"	"1.5"		// Rate of fire
-	"CycleDecrement"	"1"	// Number of bullets fired per cycle
+	"CycleDecrement"	"5"	// Number of bullets fired per cycle
 
 	"Damage"	"18"		// Damage per burst
 


### PR DESCRIPTION
Currently, Spy has 100 effective shots with the Tranq Gun. This makes the weapon incredibly spammable, which is supremely annoying because of its status effect. This change reduces the Tranq Gun's effective shots to 20. It also introduces more strategy to Spy's gameplay by making him choose between Tranq shots that can slow down his enemies and having more nails.