### PR TITLE
Increase Autorifle Spread to 0.045

### DIFF
--- a/scripts/ff_weapon_autorifle.txt
+++ b/scripts/ff_weapon_autorifle.txt
@@ -13,7 +13,7 @@ WeaponData
 	
 	// Hitscan weapons
 	"Bullets"	"1"		// Bullets to shoot
-	"BulletSpread"	"0.02"	// Spread of projectiles (Used to be 0.07)
+	"BulletSpread"	"0.045"	// Spread of projectiles (Used to be 0.07)
 
 	"PreReloadTime"	"-1"	// Time taken for the weapon to move to reload state
 	"ReloadTime"	"-1"		// Time taken to reload a shell/rocket/etc


### PR DESCRIPTION
With some playtesting we decided 0.02 was too accurate at long distances, this spread should make the Autorifle a more refined version of its vanilla form.