### PR TITLE
Make the Sniper Rifle Consume 5 Shells Per Shot

### DIFF
--- a/scripts/ff_weapon_sniperrifle.txt
+++ b/scripts/ff_weapon_sniperrifle.txt
@@ -2,7 +2,7 @@ WeaponData
 {
 	// Weapon characteristics:
 	"CycleTime"	"0.8"		// Rate of fire
-	"CycleDecrement"	"1"	// Number of bullets fired per cycle
+	"CycleDecrement"	"5"	// Number of bullets fired per cycle
 
 	"Damage"	"45"		// Damage per burst
 


### PR DESCRIPTION
Hlieb's idea, based on the same idea for Spy's Tranq Gun. This gives the Sniper Rifle less effective shots and less ability to spam.