### PR TITLE
Make Sniper Have 100 Reserve Shells (alongside 5 shells per shot for sr)

### DIFF
--- a/scripts/ff_playerclass_sniper.txt
+++ b/scripts/ff_playerclass_sniper.txt
@@ -53,7 +53,7 @@ PlayerClassData
 
 	MaxAmmoData
 	{
-		"AMMO_SHELLS"		"75"
+		"AMMO_SHELLS"		"100"
 		"AMMO_NAILS"		"75"
 		"AMMO_CELLS"		"30"
 		"AMMO_ROCKETS"	"25"


### PR DESCRIPTION
This is supposed to be added in conjunction with changing the Sniper Rifle to use 5 shells per shot. This will slightly increase Sniper's ammo pool to better fit the ammo economy Hlieb and I designed for him. It also makes up for the fact that he has only one ammo pool, instead of having shells and nails to work with as he does in other TF games.