### PR TITLE
IC is not annoying to play against

### DIFF
--- a/scripts/ff_weapon_ic.txt
+++ b/scripts/ff_weapon_ic.txt
@@ -17,13 +17,13 @@ WeaponData
 	"Bullets"	"-1"		// Bullets to shoot
 	"BulletSpread"	"-1"		// Spread of projectiles
 
-	"PreReloadTime"	"0.1"	// Time taken for the weapon to move to reload state
+	"PreReloadTime"	"0.3"	// Time taken for the weapon to move to reload state
 	"ReloadTime"	"0.65"	// Time taken to reload a shell/rocket/etc
 	"PostReloadTime"	"0.2"	// Time taken to move weapon back to firing state
 
 	"SpinTime"	"-1"		// For AC
 
-	"clip_size"	"5"
+	"clip_size"	"4" // 5 was mindless spam and juggling
 	"primary_ammo"	"AMMO_ROCKETS"
 	"secondary_ammo"	"None"
 


### PR DESCRIPTION
With RPGs Prereloading state Pyro cant effectively keep shooting after emptying his clip, but the reloading itself is pretty quick and pleasant. With clip of 4 he cant do mindless spam (that was a thing even with slower firerate) and endless juggling, but its pretty enough for long distance tries to hit someone with the ability to increase the level of damage with every shot in close ranges, 5 was way more than enough, more annoying than enough, also it standardized the amount of ammo per clip for rocket launchers