### PR TITLE
The Final Pass at the IC (Hopefully)

### DIFF
--- a/scripts/ff_weapon_ic.txt
+++ b/scripts/ff_weapon_ic.txt
@@ -1,7 +1,7 @@
 WeaponData
 {
 	// Weapon characteristics:
-	"CycleTime"	"0.8"		// Rate of fire
+	"CycleTime"	"0.25"		// Rate of fire
 	"CycleDecrement"	"1"	// Number of bullets fired per cycle
 	"DeployDelay"	"0.2"		// Delay before you can shoot when you first pull the weapon out
 	
@@ -23,7 +23,7 @@ WeaponData
 
 	"SpinTime"	"-1"		// For AC
 
-	"clip_size"	"4"
+	"clip_size"	"1"
 	"primary_ammo"	"AMMO_ROCKETS"
 	"secondary_ammo"	"None"
 


### PR DESCRIPTION
Hlieb and I did more testing and thinking and we came to the conclusion that it's just impossible to have a balanced version of the IC that has a clip of multiple rockets like FF tried to do. This thing can do 260 damage in 4 shots NOT INCLUDING the combo mechanic, which is far too generous for Pyro given the damage his flamethrower can do and the fact he can force enemies to engage with him at any time using the jetpack (also wtf how is a combo weapon thats super spammy remotely balanced).  As an alternative, this rebalance of the IC brings it closer to its TFC incarnation. It has a clip of 1 rocket, and the time to fire/begin reloading/reload the rocket takes 1.2 seconds, like the old IC of FF. It's essentially mimicking a clip-less IC like the one TFC has and FF used to have. We think this will maintain Pyro's status as a high damage dealing fighter while making him less monstrously overpowered.