### PR TITLE
Give the Sniper Rifle Recoil

### DIFF
--- a/scripts/ff_weapon_sniperrifle.txt
+++ b/scripts/ff_weapon_sniperrifle.txt
@@ -7,7 +7,7 @@ WeaponData
 	"Damage"	"45"		// Damage per burst
 
 	// for the sniper rifle, this is multiplied by the charge time (1 to 7 seconds)
-	"RecoilAmount"	"0"	// Amount of recoil
+	"RecoilAmount"	"1.0"	// Amount of recoil
 
 	// Projectile weapons
 	"Speed"	"-1"		// Speed for projectile to travel at


### PR DESCRIPTION
There seems to be a pretty neat feature to the Sniper Rifle that goes unused because it ended up having a recoil value of 0. The more charge a shot has, the more recoil you experience when firing the Sniper Rifle. I gave it a recoil value of 1 to demonstrate, and I think this is an improvement in that it makes it a little harder for Sniper to stay locked on to the same target and spam shots. To be honest, this is more of a gamefeel thing, as it feels weird to see the animation of the Sniper Rifle punching backwards when you fire it but experience no recoil. Especially because every other gun in FF has recoil.