### PR TITLE
Change the Medkit's Ammo Icon to Cells

### DIFF
--- a/scripts/ff_weapon_medkit.txt
+++ b/scripts/ff_weapon_medkit.txt
@@ -54,8 +54,8 @@ WeaponData
 		}
 		"ammo"
 		{
-			"font"	"CSTypeDeath"
-			"character"	"R"
+			"font"	"WeaponIconsSmall"
+			"character"	"6"
 		}
 		"crosshair"
 		{


### PR DESCRIPTION
Helps make gameplay mechanics more clear by showing which resource Medic is using when throwing medkits. Also makes it more evident that Medic cannot drop cells, preventing future confusion on why he can't. Additionally, new players might be confused by the seemingly random 5 appearing on the side of the screen when Medic is regenerating cells, and this makes it more obvious that Medic is regenerating a resource connected to his Medkit.