### PR TITLE
Increase IC Fire Rate to 1.2

### DIFF
--- a/scripts/ff_weapon_ic.txt
+++ b/scripts/ff_weapon_ic.txt
@@ -1,7 +1,7 @@
 WeaponData
 {
 	// Weapon characteristics:
-	"CycleTime"	"1.5"		// Rate of fire
+	"CycleTime"	"1.2"		// Rate of fire
 	"CycleDecrement"	"1"	// Number of bullets fired per cycle
 	"DeployDelay"	"0.2"		// Delay before you can shoot when you first pull the weapon out
 	


### PR DESCRIPTION
1.5 seconds is too slow, Pyros will just use the flamethrower with this fire rate. The fire rate in old versions of FF when the IC had no clip was 1.2 seconds, which fits better.