### PR TITLE
Increase Engineer's Reserve Nails Back to 50

### DIFF
--- a/scripts/ff_playerclass_engineer.txt
+++ b/scripts/ff_playerclass_engineer.txt
@@ -59,7 +59,7 @@ PlayerClassData
 	MaxAmmoData
 	{
 		"AMMO_SHELLS"		"50"
-		"AMMO_NAILS"		"30"
+		"AMMO_NAILS"		"50"
 		"AMMO_CELLS"		"200"
 		"AMMO_ROCKETS"	"30"
 		"AMMO_DETPACK"	"0"


### PR DESCRIPTION
With the Railgun no longer regenerating nails and having added movement benefits for full charges, Engineers will already be running through their nail supply much faster. Maintaining it at its original value of 50 is fair.