### PR TITLE
Make the Railgun's Default Clip 30

### DIFF
--- a/scripts/ff_weapon_railgun.txt
+++ b/scripts/ff_weapon_railgun.txt
@@ -24,7 +24,7 @@ WeaponData
 
 	"clip_size"	"-1"
 	"clip2_size"	"-1"
-	"default_clip"	"50"
+	"default_clip"	"30"
 	"default_clip2"	"-1"
 	"primary_ammo"	"AMMO_NAILS"
 	"secondary_ammo"	"None"


### PR DESCRIPTION
Fixes an issue where Engineer has 30 reserve nails but still spawns with 50 due to the Railgun's default clip being 50.