### PR TITLE
Change Reported Damage of the Sniper Rifle in the Scripts to 25 (for …

### DIFF
--- a/scripts/ff_weapon_sniperrifle.txt
+++ b/scripts/ff_weapon_sniperrifle.txt
@@ -4,7 +4,7 @@ WeaponData
 	"CycleTime"	"1.5"		// Rate of fire
 	"CycleDecrement"	"5"	// Number of bullets fired per cycle
 
-	"Damage"	"45"		// Damage per burst
+	"Damage"	"25"		// Damage per burst
 
 	// for the sniper rifle, this is multiplied by the charge time (1 to 7 seconds)
 	"RecoilAmount"	"1.0"	// Amount of recoil


### PR DESCRIPTION
…the SR nerf)

Meant to be applied alongside nerfing the SR's minimum damage to 25. Makes the scripts accurate to the internal values.