### PR TITLE
Reduce Autorifle Damage to 4

### DIFF
--- a/scripts/ff_weapon_autorifle.txt
+++ b/scripts/ff_weapon_autorifle.txt
@@ -4,7 +4,7 @@ WeaponData
 	"CycleTime"	"0.1"		// Rate of fire
 	"CycleDecrement"	"1"	// Number of bullets fired per cycle
 
-	"Damage"	"7"		// Damage per burst
+	"Damage"	"4"		// Damage per burst
 
 	"RecoilAmount"	"0.4"		// Amount of recoil
 


### PR DESCRIPTION
It was found that with a damage of 7 the Autorifle is basically a better Super Shotgun. This damage value allows the Autorifle to still act as a finishing tool secondary for Sniper while toning down its inherent power.