### PR TITLE
Quake SSG and math dilemma

### DIFF
--- a/scripts/ff_weapon_supershotgun.txt
+++ b/scripts/ff_weapon_supershotgun.txt
@@ -4,7 +4,7 @@ WeaponData
 	"CycleTime"	"0.7"		// Rate of fire
 	"CycleDecrement"	"2"	// Number of bullets fired per cycle
 
-	"Damage"	"54"		// Damage per burst
+	"Damage"	"56"		// Damage per burst
 
 	"RecoilAmount"	"0.8"		// Amount of recoil
 


### PR DESCRIPTION
54 cannot be divided normally while having 14 pellets per shot which should be avoided for longer distances, and which fits Q1 stats (ff mostly uses them)