### PR TITLE
Reduce Demoman's Max Rockets to 40

### DIFF
--- a/scripts/ff_playerclass_demoman.txt
+++ b/scripts/ff_playerclass_demoman.txt
@@ -60,7 +60,7 @@ PlayerClassData
 		"AMMO_SHELLS"		"75"
 		"AMMO_NAILS"		"50"
 		"AMMO_CELLS"		"50"
-		"AMMO_ROCKETS"	"50"
+		"AMMO_ROCKETS"	"40"
 		"AMMO_DETPACK"	"1"
 		"AMMO_MANCANNON"	"0"
 	}


### PR DESCRIPTION
Suggested by an FF player in the past, to refine Demoman's ammo count and reduce spam.