### PR TITLE
Reduce Soldier's Max Rockets to 30

### DIFF
--- a/scripts/ff_playerclass_soldier.txt
+++ b/scripts/ff_playerclass_soldier.txt
@@ -57,7 +57,7 @@ PlayerClassData
 		"AMMO_SHELLS"		"100"
 		"AMMO_NAILS"		"100"
 		"AMMO_CELLS"		"50"
-		"AMMO_ROCKETS"	"50"
+		"AMMO_ROCKETS"	"30"
 		"AMMO_DETPACK"	"0"
 		"AMMO_MANCANNON"	"0"
 	}


### PR DESCRIPTION
Suggested by an FF player in the past, to refine Soldier's ammo count and help reduce spam.