### PR TITLE
Prevent Medic to have the same capabilities as Scout to make Scout more distinct

### DIFF
--- a/scripts/ff_playerclass_medic.txt
+++ b/scripts/ff_playerclass_medic.txt
@@ -38,7 +38,7 @@ PlayerClassData
 
 	"secondary_classname"	"ff_grenade_concussion"
 	"secondary_initial"		"2"
-	"secondary_max"		"3"
+	"secondary_max"		"2"
 
 	// Ammo amounts for the player
 	AmmoData


### PR DESCRIPTION
Unorthodox change to shift and nerf for a bit 4 medics on offense meta. Conc max amount is reduced to spawn amount