### PR TITLE
Only 1 shotgun per class, being free from Quakes handcuffs

### DIFF
--- a/scripts/ff_playerclass_soldier.txt
+++ b/scripts/ff_playerclass_soldier.txt
@@ -28,7 +28,6 @@ PlayerClassData
 	ArmamentsData
 	{
 		"weapon"	"ff_weapon_crowbar"
-		"weapon"	"ff_weapon_shotgun"
 		"weapon"	"ff_weapon_supershotgun"
 		"weapon"	"ff_weapon_rpg"
 	}


### PR DESCRIPTION
Unorthodox change for the assigning the weapons required for the class. Removing redundant weapon from the class that effectively doesnt need it to be the most powerful class in the game. Both of the weapons are hitscan and consume the same the same ammo type and do the same job, i checked around 100 euro tfc pugs and none of them had soldier killing someone with the pg, ff wanted pg to be more useful by giving it tighter spread but ssg simply has larger dps at almost all the distances combats usually happen, creates an illusion of choice when in reality player will use ssg in almost every case, players use the weapon not because the class needs it but because he simply has it and want to save ammo for the ssg clip, players dont use pelletgun normally and running out of clips with both of soldiers weapon should not be forgived by giving the secondary weapon for the secondary weapon. Prevents infinite fast switch inventory abuse and artificial sustain hitscan dps. And it also confused new players of course. Its this type of change that sooner or later will come to the game so its better to finally do it, it was a suggestion for lots of times