### PR TITLE
Increase Sniper's Reserve Nails to 100

### DIFF
--- a/scripts/ff_playerclass_sniper.txt
+++ b/scripts/ff_playerclass_sniper.txt
@@ -54,7 +54,7 @@ PlayerClassData
 	MaxAmmoData
 	{
 		"AMMO_SHELLS"		"100"
-		"AMMO_NAILS"		"75"
+		"AMMO_NAILS"		"100"
 		"AMMO_CELLS"		"30"
 		"AMMO_ROCKETS"	"25"
 		"AMMO_DETPACK"	"0"


### PR DESCRIPTION
Matching his reserve nails to the TFC value now that his Sniper Rifle uses shells. Also makes him have the average amount of nails in his nailgun when playing in ff_hunted