### PR TITLE
Change Demoman's Reported Weapon Slot Order to Match Gameplay

### DIFF
--- a/scripts/ff_playerclass_demoman.txt
+++ b/scripts/ff_playerclass_demoman.txt
@@ -29,8 +29,8 @@ PlayerClassData
 	{
 		"weapon"	"ff_weapon_crowbar"
 		"weapon"	"ff_weapon_shotgun"
-		"weapon"	"ff_weapon_pipelauncher"
 		"weapon"	"ff_weapon_grenadelauncher"
+		"weapon"	"ff_weapon_pipelauncher"
 		"weapon"	"ff_weapon_deploydetpack"
 		"skill"	"detpack"
 		"skill"	"detpipes"


### PR DESCRIPTION
The script file for Demoman currently causes the order of his weapons to appear incorrectly on the class selection screen. This puts them in the right order