### PR TITLE
Civilian Rebalance

### DIFF
--- a/scripts/ff_playerclass_civilian.txt
+++ b/scripts/ff_playerclass_civilian.txt
@@ -15,10 +15,10 @@ PlayerClassData
 	"arm_model"		"models/player/arms/civilian_arms.mdl"
 
 	// Health & Armour
-	"max_armour"		"50"
+	"max_armour"		"25"
 	"initial_armour"		"25"
 	"armour_type"		"3" // this means 0.3
-	"health"			"75"
+	"health"			"50"
 
 	"speed"			"230" //5% boosted was 241
 	
@@ -52,7 +52,7 @@ PlayerClassData
 
 	MaxAmmoData
 	{
-		"AMMO_SHELLS"		"150"
+		"AMMO_SHELLS"		"0"
 		"AMMO_NAILS"		"0"
 		"AMMO_CELLS"		"0"
 		"AMMO_ROCKETS"	"0"


### PR DESCRIPTION
Matching Civilian's health to his TFC counterpart and reducing his armor to make his weakness more apparent. Also reducing his reserve shells to 0 because he was never given the Tommy Gun.